### PR TITLE
Limit header in query result screen

### DIFF
--- a/patch/mica_distribution/modules/mica/extensions/mica_datasets/mica_query/mica_query.pages.inc
+++ b/patch/mica_distribution/modules/mica/extensions/mica_datasets/mica_query/mica_query.pages.inc
@@ -1140,7 +1140,10 @@ function _mica_query_result_table($dataset_node, $query, $cross_variable, $add_l
 
 function _mica_query_run_page_header($dataset_node, $query, $term, $cross_variable, $has_multiple_terms, &$header_matched_tooltip, $add_links = TRUE) {
   $impl = $term->termImpl();
-  $title = $impl->toString();
+  $title = views_trim_text(array('max_length' => 80,
+                                 'word_boundary'=>TRUE,
+                                 'ellipsis' => TRUE),
+                           $impl->toString());
   $variable = node_load($term->variable_id);
 
   if (!empty($header_matched_tooltip)) {


### PR DESCRIPTION
A very large header of a query term in the query result screen can distort the page layout and make the page hard to read. This can happen with
ICD 10 codes if a node that has many child nodes is selected. As a fix limit the header length to 80 characters.

Fixes SESIDEV-290
