### PR TITLE
Add module sesi_variable_create_breadcrumb

### DIFF
--- a/drupalpull.sh
+++ b/drupalpull.sh
@@ -179,6 +179,7 @@ ensure_mod sesi_rules
 ensure_mod sesi_variable_email
 ensure_mod sesi_wildcard_search_processor
 ensure_mod view_own_unpublished
+ensure_mod sesi_variable_create_breadcrumb
 
 # Download Autologout module dependencies and enable it
 drush --yes dl autologout

--- a/modules/sesi_variable_create_breadcrumb/sesi_variable_create_breadcrumb.info
+++ b/modules/sesi_variable_create_breadcrumb/sesi_variable_create_breadcrumb.info
@@ -1,0 +1,6 @@
+name = Sesi Variable Create Breadcrumb
+description = Show a nicer breadcrumb on the Variable creation/edit menu
+version = "7.x"
+core = "7.x"
+package = Sesi
+project = sesi

--- a/modules/sesi_variable_create_breadcrumb/sesi_variable_create_breadcrumb.module
+++ b/modules/sesi_variable_create_breadcrumb/sesi_variable_create_breadcrumb.module
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * implement hook_form_FORM_ID_alter
+ */
+function sesi_variable_create_breadcrumb_form_variable_node_form_alter(&$form, &$form_state, $form_id) {
+
+  $variable = $form_state['node'];
+
+  if(isset($variable->nid)) {
+    $wrapper = entity_metadata_wrapper('node', $variable);
+    $dataset = $wrapper->field_dataset->value();
+  } else {
+    $dataset = _sesi_variable_create_breadcrumb_load_dataset_from_GET();
+  }
+
+  $breadcrumb = array(
+    l('Home', '<front>'),
+    l('Resources', 'resources'),
+    l('Datasets', 'datasets')
+  );
+
+  if(isset($dataset)) {
+    $breadcrumb[] = l($dataset->title, drupal_get_path_alias('node/' . $dataset->nid));
+  }
+
+  if(empty($variable->nid)) {
+    $breadcrumb[] = l('Add variable', 'node/add');
+  }
+
+  drupal_set_breadcrumb($breadcrumb);
+}
+
+/**
+ * Load a dataset from $_GET['dataset'], safely and only if the user has access.
+ *
+ * @return stdClass|null
+ */
+function _sesi_variable_create_breadcrumb_load_dataset_from_GET() {
+  if(!isset($_GET['dataset'])) return NULL;
+
+  $dsid = (int) $_GET['dataset'];
+  if($dsid == 0) return NULL;
+
+  $dataset = node_load($dsid);
+  if(empty($dataset)) return NULL;
+  if($dataset->type != 'dataset') return NULL;
+  if(!node_access('view', $dataset)) return NULL;
+
+  return $dataset;
+}


### PR DESCRIPTION
This module adds a nicer breadcrumb to the Variable create/edit screen.

Previously the breadcrumb would be "Home / Add content", now it is based on the dataset that the variable is part of or is being added to.

Fixes USESI-287
