### PR TITLE
Issues/query result screen 2

### DIFF
--- a/drupalpull.sh
+++ b/drupalpull.sh
@@ -294,6 +294,10 @@ drush php-eval 'node_access_rebuild();'
 
 drush cc all
 drush cron
+
+# Run query_ontologies database updates
+drush eval '_query_ontologies_update_schema();'
+
 drush vset maintenance_mode 0
 
 #change temporarely the snapshot

--- a/modules/query_ontologies/query_ontologies.module
+++ b/modules/query_ontologies/query_ontologies.module
@@ -39,6 +39,7 @@ function query_ontologies_menu() {
  */
 function query_ontologies_schema_alter(&$schema) {
     $options = &$schema['mica_query_term']['fields']['options'];
+    // Set size to medium, but don't decrease it if it is already set to large.
     if(!isset($options['size']) || $options['size'] != 'large') {
         $options['size'] = 'medium';
     }
@@ -55,6 +56,7 @@ function query_ontologies_schema_alter(&$schema) {
 function _query_ontologies_update_schema() {
     $schema = drupal_get_schema('mica_query_term');
     $options = $schema['fields']['options'];
-    // Our hook_schema_alter should have run before, so we have the new size.
+    // Our hook_schema_alter should have run before, so we have the new size. If any other module changed the size 
+    // after us we use that.
     db_change_field('mica_query_term', 'options', 'options', $options);
 }

--- a/modules/query_ontologies/query_ontologies.module
+++ b/modules/query_ontologies/query_ontologies.module
@@ -33,3 +33,28 @@ function query_ontologies_menu() {
     
     return $items;
 }
+
+/**
+ * implements hook_schema_alter
+ */
+function query_ontologies_schema_alter(&$schema) {
+    $options = &$schema['mica_query_term']['fields']['options'];
+    if(!isset($options['size']) || $options['size'] != 'large') {
+        $options['size'] = 'medium';
+    }
+}
+
+/*
+ * The query term table by default uses a normal text type for the 'options' field that stores the contents of a term.
+ * In Mysql that has a maximum of 64KB. The ontology term contents can get very large if all ICD10 codes are selected
+ * (about 12000), and that doesn't fit. This function idempotently enlarges the field to medium, which is 16MB in
+ * Mysql.
+ *
+ * This function is not inlined in hook_install so that we can easily call it from our installation script.
+ */
+function _query_ontologies_update_schema() {
+    $schema = drupal_get_schema('mica_query_term');
+    $options = $schema['fields']['options'];
+    // Our hook_schema_alter should have run before, so we have the new size.
+    db_change_field('mica_query_term', 'options', 'options', $options);
+}

--- a/patch/mica_distribution/modules/mica/extensions/mica_datasets/mica_query/mica_query.pages.inc
+++ b/patch/mica_distribution/modules/mica/extensions/mica_datasets/mica_query/mica_query.pages.inc
@@ -213,7 +213,10 @@ function mica_query_edit_form($form, &$form_state) {
     foreach ($terms as $query_term) {
       $data[] = array(
         'id' => $query_term->id,
-        'title' => $query_term->toString(),
+        'title' => views_trim_text(array('max_length' => 1500,
+                                         'word_boundary' => TRUE,
+                                         'ellipsis' => TRUE),
+                                   $query_term->toString()),
         'vid' => $query_term->variable_id,
         'weight' => $query_term->weight,
         'depth' => $query_term->depth,


### PR DESCRIPTION
For ontology queries, the query term can get very large if a lot of ontology terms are selected. (For ICD10 there are about 12000 codes.) The
terms are stored serialized in a single column. This change changes the column size from default to medium, which on MySql correspons to from
64KB to 16MB, which is enough for all ICD10 codes.

Part of SESIDEV-290
